### PR TITLE
bumped dependency versions

### DIFF
--- a/mentions.inc
+++ b/mentions.inc
@@ -10,7 +10,7 @@
 #define _mentions_included
 
 #include <a_samp>
-#include <YSI\y_colours>
+#include <YSI_Server\y_colours>
 
 
 enum E_COLOUR_EMBED_DATA {

--- a/mentions.inc
+++ b/mentions.inc
@@ -29,7 +29,7 @@ static embedColours[8][E_COLOUR_EMBED_DATA] = {
 	{'n', NAVY}
 };
 
-stock ExpandMentions(input[], output[], outCap, colour) {
+stock ExpandMentions(const input[], output[], outCap, colour) {
 	new
 		inLen = strlen(input),
 		outLen = 0,

--- a/pawn.json
+++ b/pawn.json
@@ -5,8 +5,8 @@
     "output": "test.amx",
     "dependencies": [
         "sampctl/samp-stdlib",
-        "Zeex/amx_assembly",
-        "pawn-lang/YSI-Includes"
+        "Zeex/amx_assembly:v1.0",
+        "pawn-lang/YSI-Includes:v5.4.102"
     ],
     "dev_dependencies": [
         "ScavengeSurvive/test-boilerplate",


### PR DESCRIPTION
- Bumped [YSI-Includes](https://github.com/pawn-lang/YSI-Includes) to `v5.4.102`.
- [amx_assembly](https://github.com/Zeex/amx_assembly) explicitly uses `v1.0`.
- Added `const` declaration to `ExpandMentions` input parameter.